### PR TITLE
chore: enforce 7-day minimum release age for supply-chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Supply-Chain Hardening: Minimum Release Age

Enforce a 7-day cooldown on package version managers so that no dependency version published less than one week ago can be resolved or installed.

### Reference

- https://socket.dev/blog/npm-introduces-minimumreleaseage-and-bulk-oidc-configuration